### PR TITLE
Fix reference to a not existing file in Ja2Set.dat.xml

### DIFF
--- a/Data-UC113/Ja2Set.dat.xml
+++ b/Data-UC113/Ja2Set.dat.xml
@@ -1027,7 +1027,7 @@
 				<file index="61">jailflor.sti</file>
 				<file index="62">hosfloor.sti</file>
 				<file index="63">p-floor3.sti</file>
-				<file index="64">flat_r1c.sti</file>
+<!--				<file index="64">flat_r1c.sti</file> --><!-- This file doesn't exist. Also this entry is deleted from UC1.13 v4.60  -->
 				<file index="65">tradroof.sti</file>
 				<file index="66">p-roof1.sti</file>
 				<file index="67">w-roof1.sti</file>


### PR DESCRIPTION
The folder `Data-UC/tilesets/19` doesn't contain any flat_r1c files. This file is also not necessary as the 4.60 version of the UC1.13 mod shows 
https://thepit.ja-galaxy-forum.com/index.php?t=msg&th=23934&goto=357359&#msg_357359

This was tested with the Data-UC files from
https://www.mediafire.com/tais113stuff#6omszlc1ydxux,1 and
https://www.mediafire.com/file/yk3xs2wpgeuaocv/Unstable_modpack.7z/file